### PR TITLE
Added logic to move the player off of Enemy's heads

### DIFF
--- a/Assets/Global/Scripts/Player/PlayerEnemyHeadDecollider.cs
+++ b/Assets/Global/Scripts/Player/PlayerEnemyHeadDecollider.cs
@@ -1,0 +1,83 @@
+using Unity.Cinemachine;
+using UnityEngine;
+
+public class PlayerEnemyHeadDecollider : MonoBehaviour
+{
+    [Header("No Player Standing On Enemy Head Slide Settings")]
+    [Tooltip("Radius of the sphere to check for enemy collision")]
+    [Range(0f, 5f)]
+    public float radius = 1f;
+    [Tooltip("Force multiplier for sliding off the enemy")]
+    [Range(0f, 100f)]
+    public float slideForceMultiplier = 10f;
+    [Tooltip("The maximum amount of upwards force to apply")]
+    [Range(0f, 1f)]
+    public float maxUpwardsForce = 0.2f;
+    [Tooltip("The minimum amount of force to add to where the camera is looking. Only if calculated force is lower than this")]
+    [Range(0f, 1f)]
+    public float minForwardsForce = 0.2f;
+
+    private PlayerObject playerObj;
+    private Rigidbody playerRigidbody;
+    private Collider playerCollider;
+    private Transform cameraTransform;
+    private int enemyLayerMask;
+
+    void Start()
+    {
+        // Cache components
+        playerObj = GlobalReference.GetReference<PlayerReference>().PlayerObj;
+        playerRigidbody = playerObj.GetComponent<Rigidbody>();
+        playerCollider = playerObj.GetComponent<Collider>();
+        cameraTransform = GlobalReference.GetReference<PlayerReference>().PlayerCamera.GetComponent<CinemachineBrain>().transform;
+        if (!playerRigidbody || !playerCollider)
+        {
+            Debug.LogError("PlayerEnemyHeadDecollider requires both player rb and collider");
+        }
+        enemyLayerMask = LayerMask.GetMask("Enemies");
+    }
+
+    void FixedUpdate()
+    {
+        HandlePenetration();
+    }
+
+    void HandlePenetration()
+    {
+        // check if there is overlap between player and enemy
+        Collider[] overlappingColliders = Physics.OverlapSphere(playerObj.transform.position, radius, enemyLayerMask);
+
+        if (overlappingColliders.Length <= 0) return;
+
+        foreach (Collider otherCollider in overlappingColliders)
+        {
+            Vector3 slideDirection = (playerObj.transform.position - otherCollider.transform.position).normalized;
+
+            Vector3 slideForce = slideDirection * slideForceMultiplier;
+            if (slideForce.x < minForwardsForce && slideForce.z < minForwardsForce)
+            {
+                Vector3 tempForce = cameraTransform.forward * minForwardsForce;
+                slideForce.x = Mathf.Max(slideForce.x, tempForce.x);
+                slideForce.z = Mathf.Max(slideForce.z, tempForce.z);
+            }
+            slideForce.y = Mathf.Max(slideDirection.y, maxUpwardsForce);
+
+            // Apply the force
+            playerRigidbody.AddForce(slideForce, ForceMode.Impulse);
+
+            Debug.Log($"Sliding off enemy! Slide Force: {slideForce}");
+        }
+    }
+
+    void OnDrawGizmos()
+    {
+        if (playerObj == null)
+            return;
+
+        // Set the color of the gizmos to distinguish it in the scene
+        Gizmos.color = Color.cyan;
+
+        // Draw a wire sphere at the player's position with the specified radius
+        Gizmos.DrawWireSphere(playerObj.transform.position, radius);
+    }
+}

--- a/Assets/Global/Scripts/Player/PlayerEnemyHeadDecollider.cs.meta
+++ b/Assets/Global/Scripts/Player/PlayerEnemyHeadDecollider.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1c9ba022289222c4ba75c9dd39e1bfec

--- a/Assets/Production/Prefabs/Player.prefab
+++ b/Assets/Production/Prefabs/Player.prefab
@@ -4905,6 +4905,7 @@ GameObject:
   - component: {fileID: 29515307043888343}
   - component: {fileID: 1671110380266321935}
   - component: {fileID: 26064138549086305}
+  - component: {fileID: 6041751897651240447}
   m_Layer: 7
   m_Name: Player
   m_TagString: PlayerPrefeb
@@ -5259,6 +5260,22 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   animator: {fileID: 2954664065970205156}
+--- !u!114 &6041751897651240447
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 637936633501757367}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1c9ba022289222c4ba75c9dd39e1bfec, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  radius: 0.8
+  slideForceMultiplier: 10
+  maxUpwardsForce: 0.1
+  minForwardsForce: 0.6
 --- !u!1 &773626285719660731
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
## Purpose of this PR:
Make it so that the player can no longer stand still on top of Enemies.

## How to test:
in any scene that has a player and enemies:
Verify the Player prefab has been updated and that the `PlayerEnemyHeadDecollider`-script is present on the Player-object.
Try jumping on any Enemy's head (or just on top of them in general) and the script should start applying force to push the player off.
There are sliders and values present in the script (and editor) to further tune this effect.

### links: 
closes #215 
