### PR TITLE
fix/#119-overwrite-basevalue

### DIFF
--- a/Assets/Global/Scripts/Player/Player.cs
+++ b/Assets/Global/Scripts/Player/Player.cs
@@ -34,7 +34,7 @@ public class Player : MonoBehaviour
 
 
     [Header("Stats")]
-    public PlayerStatistic playerStatistic;
+    public PlayerStatistic playerStatistic = new();
 
     public Tail Tail;
 
@@ -86,7 +86,6 @@ public class Player : MonoBehaviour
     
     void Awake()
     {
-        playerStatistic = new();
         playerStatistic.Generate();
 
         GlobalReference.SubscribeTo(Events.PLAYER_ATTACK_STARTED, attackingAnimation);

--- a/Assets/Global/Scripts/Player/Statistics/PlayerStatistic.cs
+++ b/Assets/Global/Scripts/Player/Statistics/PlayerStatistic.cs
@@ -32,23 +32,23 @@ public class PlayerStatistic
     }
 
     // this is for the current stats of the player
-    public CurrentStatistic Speed;
-    public CurrentStatistic JumpForce;
-    public CurrentStatistic MaxHealth;
-    public CurrentStatistic AttackSpeedMultiplier;
-    public CurrentStatistic AttackDamageMultiplier;
-    public CurrentStatistic DodgeCooldown;
-    public CurrentStatistic DoubleJumpsCount;
+    public CurrentStatistic Speed = new(12f);
+    public CurrentStatistic JumpForce = new(8f);
+    public CurrentStatistic MaxHealth = new(6f);
+    public CurrentStatistic AttackSpeedMultiplier = new(1f);
+    public CurrentStatistic AttackDamageMultiplier = new(1f);
+    public CurrentStatistic DodgeCooldown = new(1f);
+    public CurrentStatistic DoubleJumpsCount = new(1f);
 
     public void Generate() {
         GlobalReference.PermanentPlayerStatistic.Generate();
         
-        Speed = new(12f, GlobalReference.PermanentPlayerStatistic.Speed);
-        JumpForce = new(8f, GlobalReference.PermanentPlayerStatistic.JumpForce);
-        MaxHealth = new(6f, GlobalReference.PermanentPlayerStatistic.MaxHealth);
-        AttackSpeedMultiplier = new(1f, GlobalReference.PermanentPlayerStatistic.AttackSpeedMultiplier);
-        AttackDamageMultiplier = new(1f, GlobalReference.PermanentPlayerStatistic.AttackDamageMultiplier);
-        DodgeCooldown = new(1f, GlobalReference.PermanentPlayerStatistic.DodgeCooldown);
-        DoubleJumpsCount = new(1f, GlobalReference.PermanentPlayerStatistic.DoubleJumpsCount);
+        Speed.AddPermanentStats(GlobalReference.PermanentPlayerStatistic.Speed);
+        JumpForce.AddPermanentStats(GlobalReference.PermanentPlayerStatistic.JumpForce);
+        MaxHealth.AddPermanentStats(GlobalReference.PermanentPlayerStatistic.MaxHealth);
+        AttackSpeedMultiplier.AddPermanentStats(GlobalReference.PermanentPlayerStatistic.AttackSpeedMultiplier);
+        AttackDamageMultiplier.AddPermanentStats(GlobalReference.PermanentPlayerStatistic.AttackDamageMultiplier);
+        DodgeCooldown.AddPermanentStats(GlobalReference.PermanentPlayerStatistic.DodgeCooldown);
+        DoubleJumpsCount.AddPermanentStats(GlobalReference.PermanentPlayerStatistic.DoubleJumpsCount);
     }
 }

--- a/Assets/Global/Scripts/Statistics/CurrentStatistic.cs
+++ b/Assets/Global/Scripts/Statistics/CurrentStatistic.cs
@@ -16,6 +16,10 @@ public class CurrentStatistic : BaseStatistic
         permanentStatistic = perm;
     }
 
+    public void AddPermanentStats(PermanentStatistic perm) {
+        permanentStatistic = perm;
+    }
+
     // Get the final value after applying modifiers
     public float GetValue()
     {


### PR DESCRIPTION
## Purpose of this PR:
immediate initialization of field to make sure unity will overwrite the default basevalue

## How to test:
every scene that has the UI and Player prefab. Change the basevalue in the inspector of the Playerstatistic in Player (not the player prefab!!) and you should see the basevalue won't change when you press play game

### links: 
[Ticket](https://github.com/orgs/SillyBusinessInc/projects/1/views/1?pane=issue&itemId=87872213&issue=SillyBusinessInc%7CMoldbreaker%7C119)
