### PR TITLE
Fix: #240 cant cancel jump when moving in the air

### DIFF
--- a/Assets/Global/Scripts/Player/States/JumpingState.cs
+++ b/Assets/Global/Scripts/Player/States/JumpingState.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using UnityEngine.InputSystem;
 
 public class JumpingState : StateBase
 {
@@ -21,5 +22,10 @@ public class JumpingState : StateBase
     {
         // force state change if player let's go of jump button early
         if (!Player.isHoldingJump) Player.SetState(Player.states.Falling);
+    }
+
+    public override void Move(InputAction.CallbackContext ctx)
+    {
+        Player.movementInput = ctx.ReadValue<Vector2>();
     }
 }


### PR DESCRIPTION
## Purpose of this PR:
A player can now hold jump and press WASD after, the jump will still continue. 
## How to test:
Jump and right after that press a WASD key

### links: 
[Ticket](https://github.com/SillyBusinessInc/SillyBusinessGame/issues/240)
