### PR TITLE
Fix:#243 dodge particle spam fixed

### DIFF
--- a/Assets/Global/Scripts/Player/States/DodgeRollState.cs
+++ b/Assets/Global/Scripts/Player/States/DodgeRollState.cs
@@ -5,18 +5,21 @@ public class DodgeRollState : StateBase
 {
     private float timer;
 
-    public DodgeRollState(Player player) : base(player) {}
+    public DodgeRollState(Player player) : base(player) { }
 
     public override void Enter()
     {
-        // play particleSystem
-        Player.particleSystemDash.Play();
 
         // return if on cooldown
-        if (Time.time < Player.timeLastDodge + Player.playerStatistic.DodgeCooldown.GetValue()) {
+        if (Time.time < Player.timeLastDodge + Player.playerStatistic.DodgeCooldown.GetValue())
+        {
             ExitDodge();
             return;
         }
+
+        // play particleSystem
+        Player.particleSystemDash.Play();
+        
         Player.timeLastDodge = Time.time;
         Player.playerAnimationsHandler.SetBool("Dodgerolling", true);
 


### PR DESCRIPTION
## Purpose of this PR:
Dogde particle would get spammed even when cooldown was reached
## How to test:
Just spam ctrl or shift

### links: 
[Ticket](https://github.com/SillyBusinessInc/SillyBusinessGame/issues/243) 
