### PR TITLE
#286 Pause menu bugs

### DIFF
--- a/Assets/Global/Scripts/Menu/PauseLogic.cs
+++ b/Assets/Global/Scripts/Menu/PauseLogic.cs
@@ -5,6 +5,7 @@ public class PauseLogic : MonoBehaviour
 {
     public GameObject Menu;
     public GameObject Upgrades;
+    public GameObject YoP;
     private bool isPaused;
 
 
@@ -18,10 +19,12 @@ public class PauseLogic : MonoBehaviour
 
     void Update() {
         if (Input.GetKeyDown(KeyCode.Escape) && IsLoadingSceneLoaded()) { 
-            isPaused = !isPaused;
-            Menu.SetActive(!Menu.activeSelf); 
-            // Upgrades.SetActive(!Upgrades.activeSelf); 
-            Time.timeScale = isPaused ? 0f : 1f;
+            if (!YoP.activeSelf) {
+                isPaused = !isPaused;
+                Menu.SetActive(!Menu.activeSelf); 
+                // Upgrades.SetActive(!Upgrades.activeSelf); 
+                Time.timeScale = isPaused ? 0f : 1f;
+            }
         }
 
         if (isPaused == true) {

--- a/Assets/Global/Scripts/Menu/PauseLogic.cs
+++ b/Assets/Global/Scripts/Menu/PauseLogic.cs
@@ -19,11 +19,8 @@ public class PauseLogic : MonoBehaviour
     void Update() {
         if (Input.GetKeyDown(KeyCode.Escape) && IsLoadingSceneLoaded()) { 
             isPaused = !isPaused;
-            // Cursor.lockState = Cursor.lockState == CursorLockMode.Locked ? CursorLockMode.None : CursorLockMode.Locked; 
-            // Cursor.visible = !Cursor.visible;
-
             Menu.SetActive(!Menu.activeSelf); 
-            Upgrades.SetActive(!Upgrades.activeSelf); 
+            // Upgrades.SetActive(!Upgrades.activeSelf); 
             Time.timeScale = isPaused ? 0f : 1f;
         }
 
@@ -48,10 +45,9 @@ public class PauseLogic : MonoBehaviour
     }
 
     public void ContinueGame() {
-        Debug.Log(" !!! ContinueGame !!! ");
         isPaused = false;
         Menu.SetActive(!Menu.activeSelf); 
-        Upgrades.SetActive(!Upgrades.activeSelf); 
+        // Upgrades.SetActive(!Upgrades.activeSelf); 
         Cursor.lockState = CursorLockMode.Locked;
         Cursor.visible = false;
         Time.timeScale = 1f;
@@ -62,7 +58,8 @@ public class PauseLogic : MonoBehaviour
         Cursor.lockState = CursorLockMode.None;
         Cursor.visible = true;
         Menu.SetActive(!Menu.activeSelf); 
-        Upgrades.SetActive(!Upgrades.activeSelf); 
+        // Upgrades.SetActive(!Upgrades.activeSelf); 
+        Time.timeScale = 1f;
         SceneManager.LoadScene("Settings");
     }
 
@@ -71,7 +68,8 @@ public class PauseLogic : MonoBehaviour
         Cursor.lockState = CursorLockMode.None;
         Cursor.visible = true;
         Menu.SetActive(!Menu.activeSelf); 
-        Upgrades.SetActive(!Upgrades.activeSelf); 
+        // Upgrades.SetActive(!Upgrades.activeSelf);
+        Time.timeScale = 1f; 
         SceneManager.LoadScene("Menu");
     }
 }

--- a/Assets/Global/Scripts/Menu/UILogic.cs
+++ b/Assets/Global/Scripts/Menu/UILogic.cs
@@ -10,7 +10,6 @@ public static class UILogic
     public static void FadeToScene(string sceneName, Image fadeImage, MonoBehaviour target) {
         if (listening) listening = false;
         else return;
-        
         SetAlpha(0, fadeImage);
         fadeImage.gameObject.SetActive(true);
         target.StartCoroutine(Fade(sceneName, fadeImage));

--- a/Assets/Production/Scenes/Rooms/BaseScene.unity
+++ b/Assets/Production/Scenes/Rooms/BaseScene.unity
@@ -211,6 +211,10 @@ PrefabInstance:
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 3958818218294009407, guid: 13367e1bb5335e0458640101aefac0dd, type: 3}
+      propertyPath: YoP
+      value: 
+      objectReference: {fileID: 47187330}
     - target: {fileID: 4967681329817621116, guid: 13367e1bb5335e0458640101aefac0dd, type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
@@ -232,6 +236,11 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 13367e1bb5335e0458640101aefac0dd, type: 3}
+--- !u!1 &47187330 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5019536426410142992, guid: 13367e1bb5335e0458640101aefac0dd, type: 3}
+  m_PrefabInstance: {fileID: 47187329}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &343043677
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -408,7 +417,7 @@ MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 41829477981651025, guid: 13367e1bb5335e0458640101aefac0dd, type: 3}
   m_PrefabInstance: {fileID: 47187329}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
+  m_GameObject: {fileID: 47187330}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: cd03ff994ae029c40ae8dc46f7184b85, type: 3}


### PR DESCRIPTION
## Purpose of this PR:
Bug
1. When going to main menu again, you cant replay it again
2. When you pick up an upgrade, then you can go in to the pause menu, but exiting it while still in the upgrade screen, then you can walk around with the upgrade screen

## How to test:
1.  going to the main menu again, it's working correctly now2. 
2. when the upgrade screen is on the pause menu will not pop on the screen.

### links: 
https://github.com/SillyBusinessInc/Moldbreaker/issues/286