### PR TITLE
Origin/feat/#291 modify hp bar

### DIFF
--- a/Assets/Dev/PlayerHealthbar/Prefabs/UI.prefab
+++ b/Assets/Dev/PlayerHealthbar/Prefabs/UI.prefab
@@ -1288,6 +1288,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   Menu: {fileID: 3196781839337318508}
   Upgrades: {fileID: 5999346533052044171}
+  YoP: {fileID: 0}
 --- !u!1 &5019536426410142992
 GameObject:
   m_ObjectHideFlags: 0
@@ -2641,8 +2642,8 @@ GameObject:
   m_Component:
   - component: {fileID: 8241449340267907011}
   - component: {fileID: 121450397590732018}
-  - component: {fileID: 3493775325871902262}
   - component: {fileID: 2132564587033494876}
+  - component: {fileID: 8023008448355820360}
   m_Layer: 5
   m_Name: MoldMeter
   m_TagString: Untagged
@@ -2678,22 +2679,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7722653136578928598}
   m_CullTransparentMesh: 1
---- !u!114 &3493775325871902262
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7722653136578928598}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 132520a2c3dca11468fcc0d031af2107, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  MoldPercentageText: {fileID: 8927032835729698575}
-  moldPercentage: 0
-  MoldMeterImage: {fileID: 4967681329817621116}
-  animationDuration: 0.5
 --- !u!114 &2132564587033494876
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2708,6 +2693,22 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_AspectMode: 1
   m_AspectRatio: 5.3
+--- !u!114 &8023008448355820360
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7722653136578928598}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e38e270aec20c4b30bde94b9ab6592f5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  HealthPercentageText: {fileID: 8927032835729698575}
+  healthPercentage: 0
+  HealthMeterImage: {fileID: 4967681329817621116}
+  animationDuration: 0.5
 --- !u!1 &8749314788857674988
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Global/Scripts/UIScripts/HealthMeter.cs
+++ b/Assets/Global/Scripts/UIScripts/HealthMeter.cs
@@ -11,11 +11,13 @@ public class HealthMeter : MonoBehaviour
     private Coroutine moveCoroutine;
     [SerializeField] private float animationDuration = 0.5f; // Duration for smooth movement
     private float savedHealthPercentage = -1;
+    private float PlayerMaxHealth;
 
-    void Awake()
+    void Start()
     {
         player = GlobalReference.GetReference<PlayerReference>().Player;
         GlobalReference.SubscribeTo(Events.MOLDMETER_CHANGED, UpdateHealthMeter);
+        PlayerMaxHealth = player.playerStatistic.Health;
 
     }
 
@@ -28,7 +30,7 @@ public class HealthMeter : MonoBehaviour
 
     public void UpdateHealthMeter()
     {
-        healthPercentage = player.playerStatistic.Health/6*100;
+        healthPercentage = player.playerStatistic.Health/PlayerMaxHealth*100;
         // if (moldPercentage < 100) moldPercentage += 0.01f;
         if (savedHealthPercentage == healthPercentage) return;
         savedHealthPercentage = healthPercentage;

--- a/Assets/Global/Scripts/UIScripts/HealthMeter.cs
+++ b/Assets/Global/Scripts/UIScripts/HealthMeter.cs
@@ -20,9 +20,6 @@ public class HealthMeter : MonoBehaviour
 
     void Start() {
         player = GlobalReference.GetReference<PlayerReference>().Player;
-    }
-
-    void Initialize() {
         Vector3 currentScale = HealthMeterImage.localScale;
         HealthMeterImage.localScale = new Vector3(-currentScale.x, currentScale.y, currentScale.z);
     }
@@ -32,8 +29,6 @@ public class HealthMeter : MonoBehaviour
     public void UpdateHealthMeter()
     {
         if (PlayerMaxHealth == -1) PlayerMaxHealth = player.playerStatistic.Health;
-
-        Debug.Log("PlayerMaxHealth : " + PlayerMaxHealth);
         healthPercentage = player.playerStatistic.Health/PlayerMaxHealth*100;
         // if (moldPercentage < 100) moldPercentage += 0.01f;
         if (savedHealthPercentage == healthPercentage) return;

--- a/Assets/Global/Scripts/UIScripts/HealthMeter.cs
+++ b/Assets/Global/Scripts/UIScripts/HealthMeter.cs
@@ -1,0 +1,63 @@
+using UnityEngine;
+using TMPro;
+using System.Collections;
+
+public class HealthMeter : MonoBehaviour
+{
+    private Player player;
+    [SerializeField] private TMP_Text HealthPercentageText;
+    [SerializeField] private float healthPercentage;
+    [SerializeField] private RectTransform HealthMeterImage;
+    private Coroutine moveCoroutine;
+    [SerializeField] private float animationDuration = 0.5f; // Duration for smooth movement
+    private float savedHealthPercentage = -1;
+
+    void Awake()
+    {
+        player = GlobalReference.GetReference<PlayerReference>().Player;
+        GlobalReference.SubscribeTo(Events.MOLDMETER_CHANGED, UpdateHealthMeter);
+    }
+
+    void Update() => UpdateHealthMeter();
+
+    public void UpdateHealthMeter()
+    {
+        healthPercentage = player.playerStatistic.Health/6*100;
+        // if (moldPercentage < 100) moldPercentage += 0.01f;
+        if (savedHealthPercentage == healthPercentage) return;
+        savedHealthPercentage = healthPercentage;
+        
+        string decimals = healthPercentage >= 100 || healthPercentage == 0 ? "F0" : "F1";
+        HealthPercentageText.text = healthPercentage.ToString(decimals) + '%';
+
+        float barWidth = GetComponent<RectTransform>().rect.width;
+        // float targetPosX = (1 - healthPercentage / 100) * -1 * barWidth + barWidth * 0.01f;
+        // Vector2 targetPosition = new(targetPosX, HealthMeterImage.anchoredPosition.y);
+
+        float targetPosX = (healthPercentage / 100) * barWidth;
+        Vector2 targetPosition = new(targetPosX, HealthMeterImage.anchoredPosition.y);
+
+        // Start smooth movement
+        if (moveCoroutine != null)
+        {
+            StopCoroutine(moveCoroutine); // Stop any ongoing movement
+        }
+        moveCoroutine = StartCoroutine(SmoothMove(HealthMeterImage, targetPosition, animationDuration));
+    }
+
+    private IEnumerator SmoothMove(RectTransform rect, Vector2 target, float duration)
+    {
+        Vector2 startPosition = rect.anchoredPosition;
+        float elapsedTime = 0f;
+
+        while (elapsedTime < duration)
+        {
+            elapsedTime += Time.deltaTime;
+            float t = Mathf.Clamp01(elapsedTime / duration); // Normalize time (0 to 1)
+            rect.anchoredPosition = Vector2.Lerp(startPosition, target, t);
+            yield return null; // Wait for the next frame
+        }
+
+        rect.anchoredPosition = target; // Ensure it reaches the target position
+    }
+}

--- a/Assets/Global/Scripts/UIScripts/HealthMeter.cs
+++ b/Assets/Global/Scripts/UIScripts/HealthMeter.cs
@@ -16,6 +16,12 @@ public class HealthMeter : MonoBehaviour
     {
         player = GlobalReference.GetReference<PlayerReference>().Player;
         GlobalReference.SubscribeTo(Events.MOLDMETER_CHANGED, UpdateHealthMeter);
+
+    }
+
+    void Initialize() {
+        Vector3 currentScale = HealthMeterImage.localScale;
+        HealthMeterImage.localScale = new Vector3(-currentScale.x, currentScale.y, currentScale.z);
     }
 
     void Update() => UpdateHealthMeter();
@@ -31,9 +37,6 @@ public class HealthMeter : MonoBehaviour
         HealthPercentageText.text = healthPercentage.ToString(decimals) + '%';
 
         float barWidth = GetComponent<RectTransform>().rect.width;
-        // float targetPosX = (1 - healthPercentage / 100) * -1 * barWidth + barWidth * 0.01f;
-        // Vector2 targetPosition = new(targetPosX, HealthMeterImage.anchoredPosition.y);
-
         float targetPosX = (healthPercentage / 100) * barWidth;
         Vector2 targetPosition = new(targetPosX, HealthMeterImage.anchoredPosition.y);
 

--- a/Assets/Global/Scripts/UIScripts/HealthMeter.cs
+++ b/Assets/Global/Scripts/UIScripts/HealthMeter.cs
@@ -11,14 +11,15 @@ public class HealthMeter : MonoBehaviour
     private Coroutine moveCoroutine;
     [SerializeField] private float animationDuration = 0.5f; // Duration for smooth movement
     private float savedHealthPercentage = -1;
-    private float PlayerMaxHealth;
+    private float PlayerMaxHealth = -1;
 
-    void Start()
+    void Awake()
     {
-        player = GlobalReference.GetReference<PlayerReference>().Player;
         GlobalReference.SubscribeTo(Events.MOLDMETER_CHANGED, UpdateHealthMeter);
-        PlayerMaxHealth = player.playerStatistic.Health;
+    }
 
+    void Start() {
+        player = GlobalReference.GetReference<PlayerReference>().Player;
     }
 
     void Initialize() {
@@ -30,6 +31,9 @@ public class HealthMeter : MonoBehaviour
 
     public void UpdateHealthMeter()
     {
+        if (PlayerMaxHealth == -1) PlayerMaxHealth = player.playerStatistic.Health;
+
+        Debug.Log("PlayerMaxHealth : " + PlayerMaxHealth);
         healthPercentage = player.playerStatistic.Health/PlayerMaxHealth*100;
         // if (moldPercentage < 100) moldPercentage += 0.01f;
         if (savedHealthPercentage == healthPercentage) return;

--- a/Assets/Global/Scripts/UIScripts/HealthMeter.cs.meta
+++ b/Assets/Global/Scripts/UIScripts/HealthMeter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e38e270aec20c4b30bde94b9ab6592f5

--- a/Assets/Production/Scenes/Rooms/BaseScene.unity
+++ b/Assets/Production/Scenes/Rooms/BaseScene.unity
@@ -240,7 +240,8 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
+    m_RemovedGameObjects:
+    - {fileID: 3697226104033809261, guid: 13367e1bb5335e0458640101aefac0dd, type: 3}
     m_AddedGameObjects: []
     m_AddedComponents:
     - targetCorrespondingSourceObject: {fileID: 7722653136578928598, guid: 13367e1bb5335e0458640101aefac0dd, type: 3}

--- a/Assets/Production/Scenes/Rooms/BaseScene.unity
+++ b/Assets/Production/Scenes/Rooms/BaseScene.unity
@@ -236,8 +236,20 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8241449340267907011, guid: 13367e1bb5335e0458640101aefac0dd, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8241449340267907011, guid: 13367e1bb5335e0458640101aefac0dd, type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8241449340267907011, guid: 13367e1bb5335e0458640101aefac0dd, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 30
+      objectReference: {fileID: 0}
+    - target: {fileID: 8241449340267907011, guid: 13367e1bb5335e0458640101aefac0dd, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 60
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects:

--- a/Assets/Production/Scenes/Rooms/BaseScene.unity
+++ b/Assets/Production/Scenes/Rooms/BaseScene.unity
@@ -243,53 +243,13 @@ PrefabInstance:
     m_RemovedGameObjects:
     - {fileID: 3697226104033809261, guid: 13367e1bb5335e0458640101aefac0dd, type: 3}
     m_AddedGameObjects: []
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 7722653136578928598, guid: 13367e1bb5335e0458640101aefac0dd, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 47187334}
+    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 13367e1bb5335e0458640101aefac0dd, type: 3}
 --- !u!1 &47187330 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 5019536426410142992, guid: 13367e1bb5335e0458640101aefac0dd, type: 3}
   m_PrefabInstance: {fileID: 47187329}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &47187331 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 8927032835729698575, guid: 13367e1bb5335e0458640101aefac0dd, type: 3}
-  m_PrefabInstance: {fileID: 47187329}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!224 &47187332 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 4967681329817621116, guid: 13367e1bb5335e0458640101aefac0dd, type: 3}
-  m_PrefabInstance: {fileID: 47187329}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &47187333 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 7722653136578928598, guid: 13367e1bb5335e0458640101aefac0dd, type: 3}
-  m_PrefabInstance: {fileID: 47187329}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &47187334
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 47187333}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: e38e270aec20c4b30bde94b9ab6592f5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  HealthPercentageText: {fileID: 47187331}
-  healthPercentage: 0
-  HealthMeterImage: {fileID: 47187332}
-  animationDuration: 0.5
 --- !u!1001 &343043677
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Production/Scenes/Rooms/BaseScene.unity
+++ b/Assets/Production/Scenes/Rooms/BaseScene.unity
@@ -207,9 +207,17 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 3493775325871902262, guid: 13367e1bb5335e0458640101aefac0dd, type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3697226104033809261, guid: 13367e1bb5335e0458640101aefac0dd, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 3719543979606865451, guid: 13367e1bb5335e0458640101aefac0dd, type: 3}
       propertyPath: m_SizeDelta.x
-      value: 0
+      value: 11.141639
       objectReference: {fileID: 0}
     - target: {fileID: 3958818218294009407, guid: 13367e1bb5335e0458640101aefac0dd, type: 3}
       propertyPath: YoP
@@ -234,13 +242,53 @@ PrefabInstance:
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 7722653136578928598, guid: 13367e1bb5335e0458640101aefac0dd, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 47187334}
   m_SourcePrefab: {fileID: 100100000, guid: 13367e1bb5335e0458640101aefac0dd, type: 3}
 --- !u!1 &47187330 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 5019536426410142992, guid: 13367e1bb5335e0458640101aefac0dd, type: 3}
   m_PrefabInstance: {fileID: 47187329}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &47187331 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8927032835729698575, guid: 13367e1bb5335e0458640101aefac0dd, type: 3}
+  m_PrefabInstance: {fileID: 47187329}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!224 &47187332 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 4967681329817621116, guid: 13367e1bb5335e0458640101aefac0dd, type: 3}
+  m_PrefabInstance: {fileID: 47187329}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &47187333 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7722653136578928598, guid: 13367e1bb5335e0458640101aefac0dd, type: 3}
+  m_PrefabInstance: {fileID: 47187329}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &47187334
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 47187333}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e38e270aec20c4b30bde94b9ab6592f5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  HealthPercentageText: {fileID: 47187331}
+  healthPercentage: 0
+  HealthMeterImage: {fileID: 47187332}
+  animationDuration: 0.5
 --- !u!1001 &343043677
 PrefabInstance:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
## Purpose of this PR:
Instead of using the health bread, make using the mold meter as a health bar.
remove the previous hp bar(health bread).

## How to test:
in the game scene, the bar is used as a hp bar now.

### links: 
https://github.com/SillyBusinessInc/Moldbreaker/issues/291