### PR TITLE
added inactiveness on yop

### DIFF
--- a/Assets/Global/Scripts/EnableOnEvent.cs
+++ b/Assets/Global/Scripts/EnableOnEvent.cs
@@ -14,6 +14,7 @@ public class EnableOnEvent : MonoBehaviour
         }
         
         GlobalReference.SubscribeTo(this.enableEvent, EnableAll);
+        HandleYop();
     }
 
     private void EnableAll()
@@ -21,6 +22,17 @@ public class EnableOnEvent : MonoBehaviour
         foreach (var obj in objectsToEnable)
         {
             obj.SetActive(true);
+        }
+    }
+
+    void HandleYop() {
+        var roomId = GlobalReference.GetReference<GameManagerReference>().activeRoom.id;
+        var saveData = new RoomSave();
+        saveData.LoadAll();
+
+        var list = saveData.Get<List<int>>("finishedLevels");
+        if (list.Contains(roomId + 1)) { // if player already got the upgrade, don't show it
+            gameObject.SetActive(false);
         }
     }
 }

--- a/Assets/Global/Scripts/Platform/PlatformPathController.cs
+++ b/Assets/Global/Scripts/Platform/PlatformPathController.cs
@@ -89,8 +89,6 @@ public class PlatformPathController : MonoBehaviour
                 StartCoroutine(PauseAtPosition(tStartPause));
             }
         }
-
-        Debug.Log($"Segment: {currentSegment}, Reversing: {isReversing}");
     }
 
     private Vector3 GetCatmullRomPosition(float t, Vector3 p0, Vector3 p1, Vector3 p2, Vector3 p3)

--- a/Assets/Global/Scripts/Player/Player.cs
+++ b/Assets/Global/Scripts/Player/Player.cs
@@ -134,7 +134,7 @@ public class Player : MonoBehaviour
         {
             if (list.Contains(i + 1))
             {
-                upgrades[i].interactionActions.ForEach(action => action.InvokeAction());   
+                upgrades[i].interactionActions.ForEach(action => action.InvokeAction());
             }
         }
     }


### PR DESCRIPTION
## Purpose of this PR:
when you finished a room, you shouldn't be able to see or get an upgrade

## How to test:
go to the title scene and play a level, the first time you see it you should see the yeast of power box. when you finished the level exit the game and re enter the level, you should not be able to see the yop pickup anymore

### links: 
[Ticket](https://github.com/SillyBusinessInc/Moldbreaker/issues/336)
