### PR TITLE
feat/#356 levels saved as completed on entry

### DIFF
--- a/Assets/Global/Scripts/RoomLogic/RoomTransitionDoor.cs
+++ b/Assets/Global/Scripts/RoomLogic/RoomTransitionDoor.cs
@@ -31,7 +31,7 @@ public class RoomTransitionDoor : Interactable
     public void Initialize()
     {
         gameManagerReference = GlobalReference.GetReference<GameManagerReference>();
-        
+
         if (enableOnRoomFinish) GlobalReference.SubscribeTo(Events.ROOM_FINISHED, RoomFinished);
         else IsDisabled = !gameManagerReference.GetRoom(nextRoomId).unlocked;
 
@@ -75,26 +75,22 @@ public class RoomTransitionDoor : Interactable
         {
             saveData.Set("crumbs", player.playerStatistic.Crumbs);
         }
-        
+
         foreach (var secret in player.playerStatistic.Calories)
         {
             calories.Add(secret);
         }
         saveData.Set("calories", calories);
         saveData.SaveAll();
-        
+
         //to reset everything that was picked up
         player.playerStatistic.CaloriesCount = 0;
         player.playerStatistic.CrumbsCount = 0;
         player.playerStatistic.Calories.Clear();
         player.playerStatistic.Crumbs = 0;
 
-        RoomSave saveRoomData = new RoomSave();
-        saveRoomData.LoadAll();
-        List<int> finishedLevels = saveRoomData.Get<List<int>>("finishedLevels");
-        finishedLevels.Add(nextRoomId);
-        saveRoomData.Set("finishedLevels", finishedLevels);
-        saveRoomData.SaveAll();
+        // Since rooms only have one exit door, and exiting a room through this door is the 'completion' condition. We can assume that if a door with the NextRoomType: ENTRANCE is an exit door to the hub.
+        if (nextRoomType == RoomType.ENTRANCE) SaveRoomAsCompleted();
 
         for (int i = 0; i < SceneManager.sceneCount; i++)
         {
@@ -105,7 +101,7 @@ public class RoomTransitionDoor : Interactable
                 currentScenename = scene.name;
             }
         }
-        
+
         Debug.Log($"next: {nextRoomName}, nextId: {nextRoomId}, nextIndex: {nextRoomIndex}");
         saveData = new CollectableSave(nextRoomName);
         saveData.LoadAll();
@@ -169,7 +165,18 @@ public class RoomTransitionDoor : Interactable
             .FirstOrDefault(scene => scene.name != baseSceneName && scene.isLoaded).name ?? baseSceneName;
     }
 
-    [ContextMenu("Unlock Door")]public void UnlockDoor() => IsDisabled = false;
+
+    private void SaveRoomAsCompleted()
+    {
+        RoomSave saveRoomData = new RoomSave();
+        saveRoomData.LoadAll();
+        List<int> finishedLevels = saveRoomData.Get<List<int>>("finishedLevels");
+        finishedLevels.Add(doorManager.currentId);
+        saveRoomData.Set("finishedLevels", finishedLevels);
+        saveRoomData.SaveAll();
+    }
+
+    [ContextMenu("Unlock Door")] public void UnlockDoor() => IsDisabled = false;
     [ContextMenu("Lock Door")] void LockDoorTest() => IsDisabled = true;
     [ContextMenu("Open Door")] void OpenDoorTest() => OpenDoorAnimation();
     [ContextMenu("Invoke room finish event")] void InvoteRoomFinishedEvent() => GlobalReference.AttemptInvoke(Events.ROOM_FINISHED);


### PR DESCRIPTION
## Purpose of this PR:
Levels got saved as completed on entry. 
This PR makes it so that a level gets saved as completed once the level's exit door is interacted with and starts loading back into an ENTRANCE typed room (i.e ENTRANCE_1).

## How to test:
1) delete your progression: (on windows:  `%APPDATA%/../LocalLow/Silly Business/Moldbreaker_ Rise of the Loaf`) in particular the Levels.mold file
2) play the game from title.
3) enter level 1
4) exit to menu
5) continue game
6) verify only the first level is open.
7) verify in your explorer that Levels.mold hasnt been created again.
8) play and complete level 1, and leave level through the door.
9) verify second level is now open to play.
10) exit to menu.
11) verify Levels.mold has now been created on your drive.
12) continue game, verify progression has been saved due to the second level still being open.

### links: 
closes #356