### PR TITLE
Feat/#362 disable input when paused

### DIFF
--- a/Assets/Global/Scripts/Deathzone.cs
+++ b/Assets/Global/Scripts/Deathzone.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using Unity.VisualScripting;
 using UnityEngine;
 
 public class Deathzone : MonoBehaviour
@@ -42,22 +43,25 @@ public class Deathzone : MonoBehaviour
         // get the actual player object to damage.
         Player playerRef = playerReference.Player;
         playerRef.lastDamageCause = Player.DamageCause.HAZARD;
+        GlobalReference.AttemptInvoke(Events.INPUT_IGNORE);
         playerRef.OnHit(playerRef.playerStatistic.MaxHealth.GetValue() * damageAmount, new Vector3(0, 0, 0));
 
         // start the crossfade
-        if (crossfadeController) yield return StartCoroutine(crossfadeController.Crossfade_Start());
+        //if (crossfadeController) yield return StartCoroutine(crossfadeController.Crossfade_Start());
 
         // cancel out any movementinput and respawn the player on predefined spot
         playerRef.movementInput = new Vector2(0, 0);
         yield return StartCoroutine(DelayRespawn());
+        // spawnPoint.Spawn();
 
         // clear the crossfade
-        if (crossfadeController) yield return StartCoroutine(crossfadeController.Crossfade_End());
+        //if (crossfadeController) yield return StartCoroutine(crossfadeController.Crossfade_End());
+        GlobalReference.AttemptInvoke(Events.INPUT_ACKNOWLEDGE);
     }
 
     private IEnumerator DelayRespawn()
     {
-        yield return new WaitForSecondsRealtime(0.5f);
+        yield return new WaitForSecondsRealtime(0.3f);
         spawnPoint.Spawn();
     }
 }

--- a/Assets/Global/Scripts/Menu/Loader.cs
+++ b/Assets/Global/Scripts/Menu/Loader.cs
@@ -121,6 +121,7 @@ public class Loader : MonoBehaviour
     {
         message.text = "Eating the bread world...";
         GlobalReference.GetReference<GameManagerReference>().Initialize();
+        GlobalReference.AttemptInvoke(Events.INPUT_IGNORE);
         return Phase.COMPLETE;
     }
 
@@ -128,6 +129,7 @@ public class Loader : MonoBehaviour
     {
         Time.timeScale = 1;
         SceneManager.UnloadSceneAsync("Loading");
+        GlobalReference.AttemptInvoke(Events.INPUT_ACKNOWLEDGE);
         return Phase.NONE;
     }
 }

--- a/Assets/Global/Scripts/Menu/PauseLogic.cs
+++ b/Assets/Global/Scripts/Menu/PauseLogic.cs
@@ -38,6 +38,7 @@ public class PauseLogic : MonoBehaviour
     public void ContinueGame()
     {
         isPaused = false;
+        GlobalReference.AttemptInvoke(Events.INPUT_ACKNOWLEDGE);
 
         AudioManager.Instance.PlaySFX("Button");
         Menu.SetActive(!Menu.activeSelf);
@@ -51,6 +52,7 @@ public class PauseLogic : MonoBehaviour
     public void Settings()
     {
         isPaused = false;
+        GlobalReference.AttemptInvoke(Events.INPUT_ACKNOWLEDGE);
         AudioManager.Instance.PlaySFX("Button");
         Cursor.lockState = CursorLockMode.None;
         Cursor.visible = true;
@@ -63,6 +65,7 @@ public class PauseLogic : MonoBehaviour
     public void QuitGame()
     {
         isPaused = false;
+        GlobalReference.AttemptInvoke(Events.INPUT_ACKNOWLEDGE);
         AudioManager.Instance.PlaySFX("Button");
         Cursor.lockState = CursorLockMode.None;
         Cursor.visible = true;
@@ -83,6 +86,7 @@ public class PauseLogic : MonoBehaviour
             UILogic.SelectButton(continueButton);
             // Upgrades.SetActive(!Upgrades.activeSelf); 
             Time.timeScale = isPaused ? 0f : 1f;
+            GlobalReference.AttemptInvoke(Events.INPUT_IGNORE);
         }
 
         if (isPaused == true)
@@ -102,8 +106,9 @@ public class PauseLogic : MonoBehaviour
             {
                 Cursor.lockState = CursorLockMode.Locked;
                 Cursor.visible = false;
+                GlobalReference.AttemptInvoke(Events.INPUT_ACKNOWLEDGE);
+                // handler.DisableInput("UI");
             }
-            // handler.DisableInput("UI");
         }
     }
 }

--- a/Assets/Global/Scripts/Player/States/AttackingState.cs
+++ b/Assets/Global/Scripts/Player/States/AttackingState.cs
@@ -47,9 +47,10 @@ public class AttackingState : StateBase
 
     public override void Attack(InputAction.CallbackContext ctx) { }
 
-    public override void Move(InputAction.CallbackContext ctx)
+    public override void Move(InputAction.CallbackContext ctx, bool ignoreInput = false)
     {
         Player.movementInput = ctx.ReadValue<Vector2>();
+        if (ignoreInput) Player.movementInput = new Vector2(0, 0);
     }
 
     public override void Sprint(InputAction.CallbackContext ctx) { }

--- a/Assets/Global/Scripts/Player/States/DeathState.cs
+++ b/Assets/Global/Scripts/Player/States/DeathState.cs
@@ -21,7 +21,7 @@ public class DeathState : StateBase
         float linearY = ApplyGravity(Player.rb.linearVelocity.y);
         Player.targetVelocity = new Vector3(0, linearY, 0);
         time += Time.deltaTime;
-        
+
         // this is a magic spell, no one knows what it does, except the one who casted it, and he's dead now, so we will never know.
         if (Player.playerAnimationsHandler.animator.runtimeAnimatorController.animationClips.FirstOrDefault(x => x.name == "Breadaplus|Bradley_death")?.length * 0.8 <= time)
         { // (just kidding, its a check to make sure the death animation is above 80% finished)
@@ -34,8 +34,9 @@ public class DeathState : StateBase
         }
     }
 
-    public override void Move(InputAction.CallbackContext ctx)
+    public override void Move(InputAction.CallbackContext ctx, bool ignoreInput = false)
     {
+        if (ignoreInput) Player.movementInput = new Vector2(0, 0);
     }
 
     public override void Sprint(InputAction.CallbackContext ctx) { }

--- a/Assets/Global/Scripts/Player/States/HurtState.cs
+++ b/Assets/Global/Scripts/Player/States/HurtState.cs
@@ -26,7 +26,7 @@ public class HurtState : StateBase
     }
 
     public override void Hurt(Vector3 direction) { }
-    public override void Move(InputAction.CallbackContext ctx) { }
+    public override void Move(InputAction.CallbackContext ctx, bool ignoreInput = false) { if (ignoreInput) Player.movementInput = new Vector2(0, 0); }
 
     public override void Sprint(InputAction.CallbackContext ctx) { }
 

--- a/Assets/Global/Scripts/Player/States/JumpingState.cs
+++ b/Assets/Global/Scripts/Player/States/JumpingState.cs
@@ -34,8 +34,9 @@ public class JumpingState : StateBase
         if (!Player.isHoldingJump) Player.SetState(Player.states.Falling);
     }
 
-    public override void Move(InputAction.CallbackContext ctx)
+    public override void Move(InputAction.CallbackContext ctx, bool ignoreInput = false)
     {
         Player.movementInput = ctx.ReadValue<Vector2>();
+        if (ignoreInput) Player.movementInput = new Vector2(0, 0);
     }
 }

--- a/Assets/Global/Scripts/Player/States/StateBase.cs
+++ b/Assets/Global/Scripts/Player/States/StateBase.cs
@@ -19,9 +19,10 @@ public abstract class StateBase
     public virtual void OnCollisionExit(Collision collision) { }
 
     // Input handling
-    public virtual void Move(InputAction.CallbackContext ctx)
+    public virtual void Move(InputAction.CallbackContext ctx, bool ignoreInput = false)
     {
         Player.movementInput = ctx.ReadValue<Vector2>();
+        if (ignoreInput) Player.movementInput = new Vector2(0, 0);
         if (ctx.performed && Player.currentState != Player.states.Walking && Player.isGrounded)
         {
             Player.SetState(Player.states.Walking);
@@ -41,7 +42,7 @@ public abstract class StateBase
     public virtual void Dodge(InputAction.CallbackContext ctx)
     {
         if (Player.playerStatistic.CanDodge.GetValueInt() <= 0) return;
-        
+
         if (ctx.started)
         {
             Player.isHoldingDodge = true;
@@ -82,7 +83,7 @@ public abstract class StateBase
 
     public virtual void Attack(InputAction.CallbackContext ctx)
     {
-        if (ctx.started)
+        if (ctx.performed)
         {
             Player.SetState(Player.states.Attacking);
         }

--- a/Assets/Global/Scripts/PlayerInputHandler.cs
+++ b/Assets/Global/Scripts/PlayerInputHandler.cs
@@ -1,3 +1,4 @@
+using Unity.VisualScripting;
 using UnityEngine;
 using UnityEngine.InputSystem;
 
@@ -5,6 +6,8 @@ public class PlayerInputHandler : MonoBehaviour
 {
     [SerializeField] private Player player;
     [SerializeField] private PlayerInteraction interactor;
+    private GameManagerReference gameManager;
+
 
     // Handling the Input for the player.
     public void OnMove(InputAction.CallbackContext ctx)
@@ -14,36 +17,49 @@ public class PlayerInputHandler : MonoBehaviour
 
     public void OnAttack(InputAction.CallbackContext ctx)
     {
+        if (gameManager.ignoreInput) return;
         player.currentState.Attack(ctx);
     }
 
     public void OnCrouch(InputAction.CallbackContext ctx)
     {
+        if (gameManager.ignoreInput) return;
         player.currentState.Crouch(ctx);
     }
 
     public void OnSprint(InputAction.CallbackContext ctx)
     {
+        if (gameManager.ignoreInput) return;
         player.currentState.Sprint(ctx);
     }
 
     public void OnGlide(InputAction.CallbackContext ctx)
     {
+        if (gameManager.ignoreInput) return;
         player.currentState.Glide(ctx);
     }
 
     public void OnJump(InputAction.CallbackContext ctx)
     {
+        if (gameManager.ignoreInput) return;
         player.currentState.Jump(ctx);
     }
 
     public void OnDodge(InputAction.CallbackContext ctx)
     {
+        if (gameManager.ignoreInput) return;
         player.currentState.Dodge(ctx);
     }
 
     public void OnInteract(InputAction.CallbackContext ctx)
     {
+        if (gameManager.ignoreInput) return;
         interactor.Interact(ctx);
     }
+
+    void Start()
+    {
+        gameManager = GlobalReference.GetReference<GameManagerReference>();
+    }
+
 }

--- a/Assets/Global/Scripts/Reference/Events.cs
+++ b/Assets/Global/Scripts/Reference/Events.cs
@@ -47,6 +47,10 @@ public enum Events
 
     //player death
     PLAYER_DIED = 23,
-    
-    LEVELS_CHANGED = 24
+
+    LEVELS_CHANGED = 24,
+
+    // input events
+    INPUT_ACKNOWLEDGE = 25,
+    INPUT_IGNORE = 26
 }

--- a/Assets/Global/Scripts/Reference/GameObjects/GameManagerReference.cs
+++ b/Assets/Global/Scripts/Reference/GameObjects/GameManagerReference.cs
@@ -8,10 +8,15 @@ public class GameManagerReference : Reference
 {
     public Table table;
     [SerializeField] private List<RoomAmountCombo> roomAmountCombo;
+    [SerializeField] public bool ignoreInput = true;
 
-    void Start() {
+    void Start()
+    {
+        GlobalReference.SubscribeTo(Events.INPUT_ACKNOWLEDGE, () => ignoreInput = false);
+        GlobalReference.SubscribeTo(Events.INPUT_IGNORE, () => ignoreInput = true);
         // calling Initialize if scene was loaded directly (without loading screen)
-        for (int i = 0; i < SceneManager.sceneCount; i++) {
+        for (int i = 0; i < SceneManager.sceneCount; i++)
+        {
             Scene scene = SceneManager.GetSceneAt(i);
             if (!(scene.name == "Loading")) continue;
             if (!scene.isLoaded) Initialize();
@@ -20,7 +25,14 @@ public class GameManagerReference : Reference
         Initialize();
     }
 
-    public void Initialize() {
+    void OnDestroy()
+    {
+        GlobalReference.UnsubscribeTo(Events.INPUT_ACKNOWLEDGE, AcknowledgeInput);
+        GlobalReference.UnsubscribeTo(Events.INPUT_IGNORE, IgnoreInput);
+    }
+
+    public void Initialize()
+    {
         // table = new(); // disabled for structure change
         AddRoom(0, RoomType.ENTRANCE, true); // added for structure change
         AddRoom(1, RoomType.COMBAT, true); // added for structure change
@@ -31,29 +43,43 @@ public class GameManagerReference : Reference
         GlobalReference.GetReference<DoorManager>().Initialize();
     }
 
+    private void AcknowledgeInput()
+    {
+        ignoreInput = false;
+    }
+    private void IgnoreInput()
+    {
+        ignoreInput = true;
+    }
+
     #region rooms
 
     public Room activeRoom;
     private readonly List<Room> rooms = new();
 
-    public void AddRoom(int id, RoomType roomType, bool unlocked = false) {
+    public void AddRoom(int id, RoomType roomType, bool unlocked = false)
+    {
         if (rooms.Where((x) => x.id == id).Count() == 0) rooms.Add(new(id, roomType, unlocked));
     }
-    
-    public void RemoveRoom(int id) {
+
+    public void RemoveRoom(int id)
+    {
         Room room = rooms.Where((x) => x.id == id).FirstOrDefault();
-        if (room != null) rooms.Remove(room); 
+        if (room != null) rooms.Remove(room);
     }
 
     public Room GetRoom(int id) => rooms.Where((x) => x.id == id).FirstOrDefault();
     public List<Room> GetRooms() => rooms;
     public void ResetRooms() => rooms.Clear();
 
-    public List<Room> GetNextRooms() {
-        if (table == null) {
+    public List<Room> GetNextRooms()
+    {
+        if (table == null)
+        {
             Debug.Log("table is null");
         }
-        if (activeRoom == null) {
+        if (activeRoom == null)
+        {
             Debug.Log("activeRoom is null");
         }
         var connectedIds = table.GetRow(activeRoom.id).branches;
@@ -62,6 +88,7 @@ public class GameManagerReference : Reference
         Debug.Log("Connected Rooms: " + string.Join(", ", connectedRooms.Select(r => r.roomType)));
         return connectedRooms;
     }
+
 
     public int GetAmountForRoomType(RoomType roomType)
     {
@@ -73,7 +100,8 @@ public class GameManagerReference : Reference
 }
 
 [System.Serializable]
-public class RoomAmountCombo {
+public class RoomAmountCombo
+{
     public RoomType type;
     public int amount;
 }

--- a/Assets/Global/Scripts/RoomLogic/RoomTransitionDoor.cs
+++ b/Assets/Global/Scripts/RoomLogic/RoomTransitionDoor.cs
@@ -52,7 +52,7 @@ public class RoomTransitionDoor : Interactable
         // unlock next level
         Room nextLevel = gameManagerReference.GetRoom(gameManagerReference.activeRoom.id + 1);
         if (nextLevel == null) AchievementManager.Grant("RISE_OF_THE_LOAF");
-        else  nextLevel.unlocked = true;
+        else nextLevel.unlocked = true;
         AudioManager.Instance.PlaySFX("PortalSFX");
         StartCoroutine(LoadNextRoom());
         Player p = GlobalReference.GetReference<PlayerReference>().Player;
@@ -104,7 +104,7 @@ public class RoomTransitionDoor : Interactable
             }
         }
 
-        Debug.Log($"next: {nextRoomName}, nextId: {nextRoomId}, nextIndex: {nextRoomIndex}");
+        // Debug.Log($"next: {nextRoomName}, nextId: {nextRoomId}, nextIndex: {nextRoomIndex}");
         saveData = new CollectableSave(nextRoomName);
         saveData.LoadAll();
         player.playerStatistic.caloriesCountExtra = saveData.Get<List<string>>("calories").Count;

--- a/Assets/Global/Scripts/UIScripts/UpgradeOptions.cs
+++ b/Assets/Global/Scripts/UIScripts/UpgradeOptions.cs
@@ -25,6 +25,7 @@ public class UpgradeOptions : Reference
     {
         // handler.EnableInput("UI");
         isShown = true;
+        GlobalReference.AttemptInvoke(Events.INPUT_IGNORE);
         UILogic.SelectButton(confirmButton);
         SetCursorState(true, CursorLockMode.None);
         Time.timeScale = 0;
@@ -44,6 +45,7 @@ public class UpgradeOptions : Reference
         SetCursorState(false, CursorLockMode.Locked);
         gameObject.SetActive(false);
         isShown = false;
+        GlobalReference.AttemptInvoke(Events.INPUT_ACKNOWLEDGE);
         // handler.DisableInput("UI");
     }
 


### PR DESCRIPTION
## Purpose of this PR:
The purpose of this PR is to stop registering player related inputs when in a pause menu, in the yeast of power popup, and when in a deathzone.
I've also taken the liberty to comment out the waiting for the crossfade to happen on deathzone respawning. Since the crossfade just doesnt happen in game.

## How to test:
1) Play any level
2) Pause the game
3) Use inputs for movement, jump, dash
4) Unpause the game, verify none of the inputs have been registered/are being played.
5) hit a deathzone, verify the inputs arent registering/playing. verify that the respawn is now much faster.

### links: 
closes #362 