### PR TITLE
Feat/#370 wrong camera orientation

### DIFF
--- a/Assets/Global/Scripts/RoomLogic/PlayerSpawnPoint.cs
+++ b/Assets/Global/Scripts/RoomLogic/PlayerSpawnPoint.cs
@@ -9,7 +9,7 @@ public class PlayerSpawnPoint : SpawnPoint
     public override void Start()
     {
         base.Start();
-        offset = new Vector3(0, 0, 3);
+        // offset = new Vector3(0, 0, 3);
         Spawn();
     }
 }

--- a/Assets/Global/Scripts/RoomLogic/SpawnPoint.cs
+++ b/Assets/Global/Scripts/RoomLogic/SpawnPoint.cs
@@ -17,17 +17,14 @@ public class SpawnPoint : MonoBehaviour
 
     public virtual void Spawn()
     {
-        Vector3 offset = new Vector3(0, 0, 3);
-
         var playerObj = GlobalReference.GetReference<PlayerReference>().PlayerObj;
         var rb = playerObj.GetComponent<Rigidbody>();
         rb.MovePosition(this.transform.position + offset);
         Quaternion targetRotation = Quaternion.Euler(this.transform.rotation.eulerAngles.x, this.transform.rotation.eulerAngles.y + 180, this.transform.rotation.eulerAngles.z);
         rb.MoveRotation(targetRotation);
 
-        var SmoothCamaraTarget = GlobalReference.GetReference<PlayerReference>().SmoothCamaraTarget;
-        SmoothCamaraTarget.transform.position = this.transform.position + offset;
-        SmoothCamaraTarget.transform.rotation = targetRotation;
+        smoothCamaraTarget.transform.position = this.transform.position + offset;
+        smoothCamaraTarget.transform.rotation = targetRotation;
 
         StartCoroutine(AdjustPositionAndRotation(1f));
     }
@@ -35,17 +32,15 @@ public class SpawnPoint : MonoBehaviour
     private IEnumerator AdjustPositionAndRotation(float duration)
     {
 
-        var SmoothCamaraTarget = GlobalReference.GetReference<PlayerReference>().SmoothCamaraTarget.transform;
-
-        Vector3 newPosition = this.transform.position + new Vector3(0, 2, 8);
+        Vector3 newPosition = this.transform.position + new Vector3(0, 2, -8);
         Quaternion newRotation = Quaternion.Euler(this.transform.rotation.eulerAngles.x, this.transform.rotation.eulerAngles.y + 180, this.transform.rotation.eulerAngles.z);
 
         cinemachineCamera.ForceCameraPosition(newPosition, newRotation);
 
         yield return new WaitForSeconds(duration);
 
-        cinemachineCamera.Follow = SmoothCamaraTarget;
-        cinemachineCamera.LookAt = SmoothCamaraTarget;
+        cinemachineCamera.Follow = smoothCamaraTarget.transform;
+        cinemachineCamera.LookAt = smoothCamaraTarget.transform;
 
     }
 }


### PR DESCRIPTION
## Purpose of this PR:
After rotating the spawnpoint to point bradley in the right direction. Designers found the camera to face Bradley rather than face the direction Bradley is looking at. So this PR makes sure the camera is pointing the right direction.

## How to test:
1) start game, verify you see them juicy bradley buns.
2) start a level, verify you see them juicy bradley buns.
3) take a swim so you respawn, verify you see them juicy bradley buns.

### links: 
closes #370 