### PR TITLE
feedback show only at flipattack fix

### DIFF
--- a/Assets/Global/Scripts/Player/Attacks/FlipAttack.cs
+++ b/Assets/Global/Scripts/Player/Attacks/FlipAttack.cs
@@ -22,6 +22,7 @@ public class FlipAttack : TailAttack
         player.playerAnimationsHandler.ResetStates();
         player.playerAnimationsHandler.SetInt("AttackType", 2);
         player.playerAnimationsHandler.animator.SetTrigger("IsAttackingTrigger");
+        player.Tail.CanShowFeedback = true;
     }
 
     public override IEnumerator SetStateIdle()

--- a/Assets/Global/Scripts/Player/Attacks/LeftTailAttack.cs
+++ b/Assets/Global/Scripts/Player/Attacks/LeftTailAttack.cs
@@ -21,6 +21,7 @@ public class LeftTailAttack : TailAttack
         player.playerAnimationsHandler.ResetStates();
         player.playerAnimationsHandler.SetInt("AttackType", 1);
         player.playerAnimationsHandler.animator.SetTrigger("IsAttackingTrigger");
+        player.Tail.CanShowFeedback = false;
     }
 
 }

--- a/Assets/Global/Scripts/Player/Attacks/RightTailAttack.cs
+++ b/Assets/Global/Scripts/Player/Attacks/RightTailAttack.cs
@@ -21,5 +21,6 @@ public class RightTailAttack : TailAttack
         player.playerAnimationsHandler.ResetStates();
         player.playerAnimationsHandler.SetInt("AttackType", 0);
         player.playerAnimationsHandler.animator.SetTrigger("IsAttackingTrigger");
+        player.Tail.CanShowFeedback = false;
     }
 }

--- a/Assets/Global/Scripts/Player/Player.cs
+++ b/Assets/Global/Scripts/Player/Player.cs
@@ -66,8 +66,6 @@ public class Player : MonoBehaviour
     [HideInInspector] public float timeLastDodge;
     [HideInInspector] public float currentWalkingPenalty;
     [HideInInspector] public float maxWalkingPenalty = 0.5f;
-    [HideInInspector] public int recentHits = 0;
-    [HideInInspector] public int succesfullHitCounter = 0;
     [HideInInspector] public DamageCause lastDamageCause = DamageCause.NONE;
     [HideInInspector] public bool roomInvulnerability = false;
     private float currentMoldPercentage = 0;
@@ -373,9 +371,10 @@ public class Player : MonoBehaviour
 
     public void SetRandomFeedback()
     {
-        succesfullHitCounter = 0;
-        var f = rb.gameObject.GetComponentInChildren<FeedbackManager>();
-        f.SetRandomFeedback();
+        if (Tail.CanShowFeedback) {
+            var f = rb.gameObject.GetComponentInChildren<FeedbackManager>();
+            f.SetRandomFeedback();
+        }
     }
 
 }

--- a/Assets/Global/Scripts/Player/Player.cs
+++ b/Assets/Global/Scripts/Player/Player.cs
@@ -75,7 +75,7 @@ public class Player : MonoBehaviour
     [HideInInspector] public float maxWalkingPenalty = 0.5f;
     [HideInInspector] public int recentHits = 0;
     [HideInInspector] public float lastHitTime = 0f;
-    public float hitCooldown = 2f;
+    public float hitCooldown = 4f;
     
     [Header("Debugging")]
     [SerializeField] public bool isGrounded;

--- a/Assets/Global/Scripts/Player/States/AttackingState.cs
+++ b/Assets/Global/Scripts/Player/States/AttackingState.cs
@@ -30,11 +30,6 @@ public class AttackingState : StateBase
         currentCombo.Start();
         Player.StartCoroutine(currentCombo.SetStateIdle());
         IncreaseIndex();
-
-        if (Player.recentHits > 0) Player.succesfullHitCounter += 1;
-        else Player.succesfullHitCounter = 0;
-        // Debug.Log($"recent: {Player.recentHits}, succesfull: {Player.succesfullHitCounter}");
-        Player.recentHits = 0;
     }
 
     public override void Exit()

--- a/Assets/Global/Scripts/Player/Tails/FlipCollidor.cs
+++ b/Assets/Global/Scripts/Player/Tails/FlipCollidor.cs
@@ -14,7 +14,6 @@ public class FlipCollidor : MonoBehaviour
         float actualDamage = player.Tail.tailDoDamage * player.playerStatistic.AttackDamageMultiplier.GetValue();
         Collider.GetComponent<EnemiesNS.EnemyBase>().OnHit((int)MathF.Round(actualDamage, 0), DamageCause.PLAYER);
 
-        player.recentHits += 1;
-        if (player.succesfullHitCounter == player.Tail.currentTail.currentCombo.Count - 1) player.SetRandomFeedback();
+        player.SetRandomFeedback();
     }
 }

--- a/Assets/Global/Scripts/Player/Tails/FlipCollidor.cs
+++ b/Assets/Global/Scripts/Player/Tails/FlipCollidor.cs
@@ -14,6 +14,8 @@ public class FlipCollidor : MonoBehaviour
         float actualDamage = player.Tail.tailDoDamage * player.playerStatistic.AttackDamageMultiplier.GetValue();
         Collider.GetComponent<EnemiesNS.EnemyBase>().OnHit((int)MathF.Round(actualDamage, 0), DamageCause.PLAYER);
 
+        player.recentHits += 1;
+        player.lastHitTime = Time.time;
         player.SetRandomFeedback();
     }
 }

--- a/Assets/Global/Scripts/Player/Tails/Tail.cs
+++ b/Assets/Global/Scripts/Player/Tails/Tail.cs
@@ -22,6 +22,8 @@ public class Tail : MonoBehaviour
     public GameObject slamObject;
     [HideInInspector] public float slamObjectSize = 1.0f;
 
+    public bool CanShowFeedback = false;
+
     public void Start() {}
 
     public void Update()
@@ -56,10 +58,6 @@ public class Tail : MonoBehaviour
         Collider.GetComponent<EnemiesNS.EnemyBase>().OnHit((int)MathF.Round(actualDamage, 0), DamageCause.PLAYER);
 
         // displays feedback message when there's a combo
-        // if (attackIndex == currentTail.currentCombo.Count) {
-        //     player.SetRandomFeedback();
-        // }
-        player.recentHits += 1;
-        if (player.succesfullHitCounter == currentTail.currentCombo.Count - 1) player.SetRandomFeedback();
+        player.SetRandomFeedback();
     }
 }

--- a/Assets/Global/Scripts/Player/Tails/Tail.cs
+++ b/Assets/Global/Scripts/Player/Tails/Tail.cs
@@ -58,6 +58,8 @@ public class Tail : MonoBehaviour
         Collider.GetComponent<EnemiesNS.EnemyBase>().OnHit((int)MathF.Round(actualDamage, 0), DamageCause.PLAYER);
 
         // displays feedback message when there's a combo
+        player.recentHits += 1;
+        player.lastHitTime = Time.time;
         player.SetRandomFeedback();
     }
 }


### PR DESCRIPTION
## Purpose of this PR:
the feedback will only show when the attack is a flip attack

## How to test:
attack an enemy and show it when there's a combo

### links: 
[Ticket](https://github.com/SillyBusinessInc/Moldbreaker/issues/378)
