### PR TITLE
Feat/#390 camera orientation on spawn is wrong again

### DIFF
--- a/Assets/Global/Scripts/RoomLogic/SpawnPoint.cs
+++ b/Assets/Global/Scripts/RoomLogic/SpawnPoint.cs
@@ -4,40 +4,116 @@ using UnityEngine;
 
 public class SpawnPoint : MonoBehaviour
 {
-    [SerializeField]
-    protected Vector3 offset = new Vector3(0, 0, 0);
+    [SerializeField] protected Vector3 offset = new Vector3(0, 0, 0);
     private CinemachineCamera cinemachineCamera;
     private SmoothTarget smoothCamaraTarget;
 
+    [Header("Camera Settings")]
+    [SerializeField] private float cameraDistance = 8f;
+    [SerializeField] private float initializationDelay = 0.1f;
+
     public virtual void Start()
     {
-        cinemachineCamera = GlobalReference.GetReference<PlayerReference>().CinemachineCamera;
-        smoothCamaraTarget = GlobalReference.GetReference<PlayerReference>().SmoothCamaraTarget;
+        var playerRef = GlobalReference.GetReference<PlayerReference>();
+        cinemachineCamera = playerRef.CinemachineCamera;
+        smoothCamaraTarget = playerRef.SmoothCamaraTarget;
+
+        if (IsInitialSpawnPoint())
+        {
+            StartCoroutine(InitialSpawn());
+        }
+    }
+
+    private bool IsInitialSpawnPoint()
+    {
+        return gameObject.CompareTag("InitialSpawn");
+    }
+
+    private IEnumerator InitialSpawn()
+    {
+        yield return new WaitForSeconds(initializationDelay);
+
+        if (smoothCamaraTarget != null)
+        {
+            smoothCamaraTarget.transform.position = transform.position + offset;
+            smoothCamaraTarget.transform.rotation = transform.rotation;
+        }
+
+        Spawn();
     }
 
     public virtual void Spawn()
     {
-        var playerObj = GlobalReference.GetReference<PlayerReference>().PlayerObj;
+        var playerRef = GlobalReference.GetReference<PlayerReference>();
+        var playerObj = playerRef.PlayerObj;
         var rb = playerObj.GetComponent<Rigidbody>();
-        rb.MovePosition(this.transform.position + offset);
-        Quaternion targetRotation = Quaternion.Euler(this.transform.rotation.eulerAngles.x, this.transform.rotation.eulerAngles.y + 180, this.transform.rotation.eulerAngles.z);
+
+        Quaternion targetRotation = Quaternion.Euler(
+            transform.rotation.eulerAngles.x,
+            transform.rotation.eulerAngles.y + 180,
+            transform.rotation.eulerAngles.z);
+
+        // Position and rotate player
+        rb.MovePosition(transform.position + offset);
         rb.MoveRotation(targetRotation);
 
-        transform.SetPositionAndRotation(transform.position + offset, targetRotation);
+        // Update smooth target to match player
+        if (smoothCamaraTarget != null)
+        {
+            smoothCamaraTarget.transform.position = transform.position + offset;
+            smoothCamaraTarget.transform.rotation = targetRotation;
+        }
 
-        StartCoroutine(AdjustPositionAndRotation(1f));
+        StartCoroutine(AdjustCamera());
     }
 
-    private IEnumerator AdjustPositionAndRotation(float duration)
+    private IEnumerator AdjustCamera()
     {
-        Vector3 newPosition = this.transform.position + new Vector3(0, 2, -8);
-        Quaternion newRotation = Quaternion.Euler(this.transform.rotation.eulerAngles.x, this.transform.rotation.eulerAngles.y + 180, this.transform.rotation.eulerAngles.z);
+        if (cinemachineCamera == null)
+        {
+            Debug.LogError("[SpawnPoint] CinemachineCamera is null!");
+            yield break;
+        }
 
-        cinemachineCamera.ForceCameraPosition(newPosition, newRotation);
+        // Calculate camera position behind the player (same direction as player facing)
+        Vector3 cameraOffset = transform.forward * cameraDistance;
+        Vector3 newCameraPosition = transform.position + offset + cameraOffset;
 
-        yield return new WaitForSeconds(duration);
+        Quaternion newCameraRotation = Quaternion.Euler(
+            transform.rotation.eulerAngles.x,
+            transform.rotation.eulerAngles.y + 180,
+            transform.rotation.eulerAngles.z);
+
+        cinemachineCamera.ForceCameraPosition(newCameraPosition, newCameraRotation);
+
+        yield return null;
 
         cinemachineCamera.Follow = smoothCamaraTarget.transform;
         cinemachineCamera.LookAt = smoothCamaraTarget.transform;
+    }
+
+    private void OnDrawGizmos()
+    {
+        // Draw spawn position
+        Gizmos.color = Color.green;
+        Vector3 spawnPos = transform.position + offset;
+        Gizmos.DrawWireSphere(spawnPos, 0.5f);
+
+        // Draw expected camera position
+        Gizmos.color = Color.yellow;
+        Vector3 cameraPos = spawnPos + (transform.forward * cameraDistance); // Removed the negative
+        Gizmos.DrawWireSphere(cameraPos, 0.3f);
+
+        // Draw line from spawn to camera
+        Gizmos.color = Color.red;
+        Gizmos.DrawLine(spawnPos, cameraPos);
+
+        // Draw player forward direction
+        Gizmos.color = Color.blue;
+        Quaternion playerRot = Quaternion.Euler(transform.rotation.eulerAngles.x,
+            transform.rotation.eulerAngles.y + 180,
+            transform.rotation.eulerAngles.z);
+        Vector3 playerForward = playerRot * Vector3.forward;
+        Gizmos.DrawRay(spawnPos, playerForward * 2f);
     }
 }

--- a/Assets/Production/Prefabs/Functional/Deathzone/Spawnpoint.prefab
+++ b/Assets/Production/Prefabs/Functional/Deathzone/Spawnpoint.prefab
@@ -155,3 +155,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   offset: {x: 0, y: 0, z: 0}
+  enableDebugLines: 1
+  debugDuration: 5
+  logDebugInfo: 1

--- a/Assets/Production/Prefabs/Functional/Gates/PlayerSpawnPoint.prefab
+++ b/Assets/Production/Prefabs/Functional/Gates/PlayerSpawnPoint.prefab
@@ -44,3 +44,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 3382ff04455de47558a925909a1696d4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  offset: {x: 0, y: 0, z: 0}
+  enableDebugLines: 1
+  debugDuration: 5
+  logDebugInfo: 1


### PR DESCRIPTION
## Purpose of this PR:
The camera spawn orientation got borked again, so it's fixed again.

## How to test:
1) start game / continue game
2) verify the camera is in line with where Bradley is looking.
3) load into level, verify the camera is in line with where Bradley is looking
4) hit a deathzone, verify the camera is in line with where Bradley is looking

\* in line with where bradley is looking means you are looking at it's caked up ass cheeks, and not at his ~~eyes~~ personality

### links: 
closes #390 