### PR TITLE
made something monobehaviour where it didnt have to, so fixed now

### DIFF
--- a/Assets/Global/Scripts/Enhancements/Announcements/DotIndicator.cs
+++ b/Assets/Global/Scripts/Enhancements/Announcements/DotIndicator.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
 using UnityEngine.UI;
 
-public class DotIndicator : MonoBehaviour
+public class DotIndicator
 {
     public Image backgroundImage;
     public Image fillImage;

--- a/Assets/Production/Prefabs/Functional/CarrouselDot.prefab
+++ b/Assets/Production/Prefabs/Functional/CarrouselDot.prefab
@@ -87,7 +87,6 @@ GameObject:
   - component: {fileID: 2165768996881625340}
   - component: {fileID: 7199320681344251125}
   - component: {fileID: 6064063958920938945}
-  - component: {fileID: 1744909604579728336}
   m_Layer: 5
   m_Name: CarrouselDot
   m_TagString: Untagged
@@ -167,17 +166,3 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   autoScale: 1
   padding: 7
---- !u!114 &1744909604579728336
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3385771899838843594}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ce0e00b0fce7c324ea18bfb2b75a6145, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  backgroundImage: {fileID: 7199320681344251125}
-  fillImage: {fileID: 1418109940163610982}


### PR DESCRIPTION
## Purpose of this PR:
Small fix for some unity warnings in the DotIndicator class
Was Monobehaviour where it didnt have to be, so using new rather than instantiate caused unity to throw some warnings i didnt spot before.

## How to test:
run the game, get into main menu, keep an eye on console.

### links: 
none, just a hotfix.
